### PR TITLE
CompatHelper: add new compat entry for SpeciesInteractionNetworks at version 0.0.1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,3 +6,6 @@ version = "0.1.0"
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 SpeciesInteractionNetworks = "49e116ef-912f-4766-9e56-896a49944adc"
+
+[compat]
+SpeciesInteractionNetworks = "0.0.1"


### PR DESCRIPTION
This pull request sets the compat entry for the `SpeciesInteractionNetworks` package to `0.0.1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.